### PR TITLE
Feature add consumer validation and issuer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "no.nav.samordning"
@@ -62,5 +63,9 @@ tasks{
     test {
         useJUnitPlatform()
     }
-
+    withType<Test> {
+        testLogging {
+            events(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,8 @@ val slf4jVersion = "1.7.30"
 val log4jVersion = "2.13.3"
 
 plugins {
-    kotlin("jvm") version "1.3.72"
-    kotlin("plugin.spring") version "1.3.72"
+    kotlin("jvm") version "1.4.31"
+    kotlin("plugin.spring") version "1.4.31"
     id("org.springframework.boot") version "2.3.0.RELEASE"
     id("io.spring.dependency-management") version "1.0.9.RELEASE"
 }
@@ -34,6 +34,7 @@ dependencies {
     implementation("org.springframework.boot","spring-boot-starter-oauth2-resource-server")
     implementation("org.springframework.security.oauth","spring-security-oauth2","2.5.0.RELEASE")
     implementation("org.springframework.cloud","spring-cloud-vault-config-databases","2.2.2.RELEASE")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     runtimeOnly("org.springframework.cloud","spring-cloud-starter-vault-config","2.1.3.RELEASE")
     testImplementation(kotlin("test-junit5"))
     testImplementation("org.springframework.boot","spring-boot-starter-test") {

--- a/src/main/kotlin/no/nav/samordning/hendelser/consumer/Consumer.kt
+++ b/src/main/kotlin/no/nav/samordning/hendelser/consumer/Consumer.kt
@@ -1,0 +1,12 @@
+package no.nav.samordning.hendelser.consumer
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class Consumer(
+    // Eksempel "0192:991825827"
+    @JsonProperty("ID") val consumerOrgno: String
+) {
+    fun getOrgno() = this.consumerOrgno.substringAfter(":")
+}

--- a/src/main/kotlin/no/nav/samordning/hendelser/consumer/Consumer.kt
+++ b/src/main/kotlin/no/nav/samordning/hendelser/consumer/Consumer.kt
@@ -2,11 +2,17 @@ package no.nav.samordning.hendelser.consumer
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 class Consumer(
-    // Eksempel "0192:991825827"
+    // Example "0192:991825827"
     @JsonProperty("ID") val consumerOrgno: String
 ) {
     fun getOrgno() = this.consumerOrgno.substringAfter(":")
+
+    companion object {
+        fun parse(consumerObject: String) = jacksonObjectMapper().readValue<Consumer>(consumerObject)
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,7 @@ management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=prometheus, health
 
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${JWK_SET_URI}
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${ISSUER_URL}
 spring.datasource.hikari.maximum-pool-size=${MAX_POOL_SIZE}
 
 logging.level.no.nav.samordning.hendelser=${LOG_LEVEL}

--- a/src/test/kotlin/no/nav/samordning/hendelser/TestAuthHelper.kt
+++ b/src/test/kotlin/no/nav/samordning/hendelser/TestAuthHelper.kt
@@ -9,12 +9,12 @@ object TestAuthHelper {
     private const val AUTH_SCHEME = "Bearer"
 
     @Throws(NoSuchAlgorithmException::class)
-    fun token(orgno: String, verifiedSignature: Boolean) =
-            header(TestTokenHelper.token(orgno, verifiedSignature))
+    fun token(orgno: String, verifiedSignature: Boolean, iss: String? = "https://badserver/provider/") =
+        header(TestTokenHelper.token(orgno, verifiedSignature, iss))
 
-    fun expiredToken(orgno: String) = header(createExpiredJwt(orgno))
+    fun expiredToken(orgno: String, iss: String?) = header(createExpiredJwt(orgno, iss))
 
-    fun futureToken(orgno: String) = header(createFutureJwt(orgno))
+    fun futureToken(orgno: String, iss: String?) = header(createFutureJwt(orgno, iss))
 
     fun serviceToken() = header(TestTokenHelper.serviceToken())
 

--- a/src/test/kotlin/no/nav/samordning/hendelser/TestTokenHelper.kt
+++ b/src/test/kotlin/no/nav/samordning/hendelser/TestTokenHelper.kt
@@ -21,13 +21,13 @@ object TestTokenHelper {
         get() = publicKey(keyPair).modulus.toByteArray()
 
     @Throws(NoSuchAlgorithmException::class)
-    fun token(orgno: String, verifiedSignature: Boolean) = token(DEFAULT_SCOPE, orgno, verifiedSignature)
+    fun token(orgno: String, verifiedSignature: Boolean, iss: String? = "https://badserver/provider/") = token(DEFAULT_SCOPE, orgno, verifiedSignature, iss)
 
     @Throws(NoSuchAlgorithmException::class)
-    fun token(scope: String, orgno: String, verifiedSignature: Boolean): String {
+    fun token(scope: String, orgno: String, verifiedSignature: Boolean, iss: String? = "https://badserver/provider/"): String {
         val signingKeys = if (verifiedSignature) keyPair else generatedKeyPair
         val algorithm = Algorithm.RSA256(publicKey(signingKeys), privateKey(signingKeys))
-        return createJwt(scope, orgno, algorithm)
+        return createJwt(scope, orgno, algorithm, iss)
     }
 
     fun serviceToken() = createServiceJwt(algorithm)!!
@@ -47,19 +47,19 @@ object TestTokenHelper {
                 }""".trimMargin(),
             Base64.getUrlEncoder().encodeToString(keyModulus))
 
-    internal fun createExpiredJwt(orgno: String) = addClaims(expiredJwt, orgno, algorithm)
+    internal fun createExpiredJwt(orgno: String, iss: String?) = addClaims(expiredJwt, orgno, algorithm, iss)
 
-    internal fun createFutureJwt(orgno: String) = addClaims(futureJwt, orgno, algorithm)
+    internal fun createFutureJwt(orgno: String, iss: String?) = addClaims(futureJwt, orgno, algorithm, iss)
 
-    private fun createJwt(scope: String, orgno: String, algorithm: Algorithm) =
-            addClaims(JWT.create(), scope, orgno, algorithm)
+    private fun createJwt(scope: String, orgno: String, algorithm: Algorithm, iss: String?) =
+            addClaims(JWT.create(), scope, orgno, algorithm, iss)
 
-    private fun addClaims(jwt: JWTCreator.Builder, orgno: String, algorithm: Algorithm) =
-            addClaims(jwt, DEFAULT_SCOPE, orgno, algorithm)
+    private fun addClaims(jwt: JWTCreator.Builder, orgno: String, algorithm: Algorithm, iss: String?) =
+            addClaims(jwt, DEFAULT_SCOPE, orgno, algorithm, iss)
 
-    private fun addClaims(jwt: JWTCreator.Builder, scope: String, orgno: String, algorithm: Algorithm) = jwt
+    private fun addClaims(jwt: JWTCreator.Builder, scope: String, orgno: String, algorithm: Algorithm, iss: String?) = jwt
             .withArrayClaim("aud", arrayOf("tp_ordning", "preprod"))
-            .withClaim("iss", "https://badserver/provider/")
+            .withClaim("iss", iss)
             .withClaim("scope", scope)
             .withClaim("client_id", "tp_ordning")
             .withClaim("consumer", """{ "authority" : "iso6523-actorid-upis", "ID" : "0192:$orgno"}""")

--- a/src/test/kotlin/no/nav/samordning/hendelser/TestTokenHelper.kt
+++ b/src/test/kotlin/no/nav/samordning/hendelser/TestTokenHelper.kt
@@ -61,9 +61,7 @@ object TestTokenHelper {
             .withArrayClaim("aud", arrayOf("tp_ordning", "preprod"))
             .withClaim("iss", iss)
             .withClaim("scope", scope)
-            .withClaim("client_id", "tp_ordning")
             .withClaim("consumer", """{ "authority" : "iso6523-actorid-upis", "ID" : "0192:$orgno"}""")
-        //.withClaim("client_orgno", orgno)
             .sign(algorithm)
 
     private fun createServiceJwt(algorithm: Algorithm) = JWT.create()

--- a/src/test/kotlin/no/nav/samordning/hendelser/TestTokenHelper.kt
+++ b/src/test/kotlin/no/nav/samordning/hendelser/TestTokenHelper.kt
@@ -62,7 +62,8 @@ object TestTokenHelper {
             .withClaim("iss", "https://badserver/provider/")
             .withClaim("scope", scope)
             .withClaim("client_id", "tp_ordning")
-            .withClaim("client_orgno", orgno)
+            .withClaim("consumer", """{ "authority" : "iso6523-actorid-upis", "ID" : "0192:$orgno"}""")
+        //.withClaim("client_orgno", orgno)
             .sign(algorithm)
 
     private fun createServiceJwt(algorithm: Algorithm) = JWT.create()

--- a/src/test/kotlin/no/nav/samordning/hendelser/feed/FeedControllerAuthTest.kt
+++ b/src/test/kotlin/no/nav/samordning/hendelser/feed/FeedControllerAuthTest.kt
@@ -44,7 +44,7 @@ internal class FeedControllerAuthTest {
     @Throws(Exception::class)
     fun expired_token_is_unauthorized() {
         mockMvc.perform(get(ENDPOINT)
-                .header(AUTH_HEADER_NAME, expiredToken(ORG_NUMBER_2))
+                .header(AUTH_HEADER_NAME, expiredToken(ORG_NUMBER_2, "https://badserver/provider/"))
                 .param(TPNR_PARAM_NAME, TPNR_2))
                 .andExpect(status().isUnauthorized)
     }
@@ -53,8 +53,17 @@ internal class FeedControllerAuthTest {
     @Throws(Exception::class)
     fun future_token_is_unauthorized() {
         mockMvc.perform(get(ENDPOINT)
-                .header(AUTH_HEADER_NAME, futureToken(ORG_NUMBER_2))
+                .header(AUTH_HEADER_NAME, futureToken(ORG_NUMBER_2, "https://badserver/provider/"))
                 .param(TPNR_PARAM_NAME, TPNR_2))
+                .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun invalid_token_signature_is_unauthorized() {
+        mockMvc.perform(get(ENDPOINT)
+                .header(AUTH_HEADER_NAME, token(ORG_NUMBER_1, false))
+                .param(TPNR_PARAM_NAME, TPNR_1))
                 .andExpect(status().isUnauthorized)
     }
 
@@ -62,9 +71,9 @@ internal class FeedControllerAuthTest {
     @Throws(Exception::class)
     fun invalid_token_issuer_is_unauthorized() {
         mockMvc.perform(get(ENDPOINT)
-                .header(AUTH_HEADER_NAME, token(ORG_NUMBER_1, false))
-                .param(TPNR_PARAM_NAME, TPNR_1))
-                .andExpect(status().isUnauthorized)
+            .header(AUTH_HEADER_NAME, token(ORG_NUMBER_1, false, "http://localhost:8080"))
+            .param(TPNR_PARAM_NAME, TPNR_1))
+            .andExpect(status().isUnauthorized)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/samordning/hendelser/security/TokenResolverTest.kt
+++ b/src/test/kotlin/no/nav/samordning/hendelser/security/TokenResolverTest.kt
@@ -71,7 +71,7 @@ internal class TokenResolverTest {
 
         val exception = assertThrows(OAuth2AuthenticationException::class.java) { resolver.resolve(request) }
 
-        assertEquals("Missing parameters: client_id, client_orgno, scope", exception.message)
+        assertEquals("Missing parameters: client_id, consumer, scope", exception.message)
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/samordning/hendelser/security/TokenResolverTest.kt
+++ b/src/test/kotlin/no/nav/samordning/hendelser/security/TokenResolverTest.kt
@@ -3,7 +3,9 @@ package no.nav.samordning.hendelser.security
 import no.nav.samordning.hendelser.TestTokenHelper.serviceToken
 import no.nav.samordning.hendelser.TestTokenHelper.token
 import no.nav.samordning.hendelser.consumer.TpregisteretConsumer
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
@@ -71,7 +73,7 @@ internal class TokenResolverTest {
 
         val exception = assertThrows(OAuth2AuthenticationException::class.java) { resolver.resolve(request) }
 
-        assertEquals("Missing parameters: client_id, consumer, scope", exception.message)
+        assertEquals("Missing parameters: consumer, scope", exception.message)
     }
 
     companion object {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,6 +3,7 @@ spring.profiles.active=test
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=prometheus, health
 
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://badserver/provider/
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=placeholder
 
 NEXT_BASE_URL=http://localhost


### PR DESCRIPTION
Configuration before did not validate issuer. Added this as is required to be validated for a jwt:  `The issuer identifier is used to prevent authorization server mix-up attacks`: https://tools.ietf.org/id/draft-ietf-oauth-discovery-08.html.

Added feat to validate maskinporten, some configuration need to be made in vault or where ever the `JWK_SET_URI` is configured also `ISSUER_URL` need to be added to dev and prod environment. 
jwks dev: `https://ver2.maskinporten.no/jwk`
jwks prod: `https://maskinporten.no/jwk`
issuer url dev: `https://ver2.maskinporten.no/`
issuer url prod: `https://maskinporten.no/` 

As for `client_id` and `client_org` is not a required/provided claims by maskinporten. ref: https://docs.digdir.no/maskinporten_guide_apitilbyder.html#eksempel-p%C3%A5-token

`client_org` is replaced with: 
```
 "consumer" : {
    "authority" : "iso6523-actorid-upis",
    "ID" : "0192:991825827"
  }
```

some smaller changes to indent to code been made, updated old kotlin dep. added jackson for mapping added som test output.
