### PR TITLE
docs(ros): legg til ROS for PersonFeed og ManglendeRefusjonFeed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ target/
 /.gradle/
 /build/
 /out/
+
+# Generated ROS PDF (regenerate with: cd docs/ros && python3 generate-pdf.py)
+docs/ros/*.pdf

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Dokumentasjon: [Preprod](https://api-portal-preprod.nav.no/docs/services/pensjon
 
 Dokumentasjon: [Prod](https://api-portal.nav.no/docs/services/nav-pensjon-v1-samordning/operations/HendelserGet) 
 
+## Risiko- og sårbarhetsanalyse (ROS)
+
+- [PersonFeedController](docs/ros/ros-person-feed.md)
+- [ManglendeRefusjonFeedController](docs/ros/ros-manglende-refusjon-feed.md)
+
+Generer PDF: `cd docs/ros && python3 generate-pdf.py`
+
 # Henvendelser
 
 Spørsmål knyttet til koden eller prosjektet kan stilles som issues her på GitHub.

--- a/docs/ros/generate-pdf.py
+++ b/docs/ros/generate-pdf.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Generate a styled PDF for the ROS analysis of samordning-hendelse-api feeds."""
+
+import subprocess
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+OUTPUT_PDF = os.path.join(SCRIPT_DIR, "ros-samordning-feeds.pdf")
+
+MARKDOWN_FILES = [
+    os.path.join(SCRIPT_DIR, "ros-person-feed.md"),
+    os.path.join(SCRIPT_DIR, "ros-manglende-refusjon-feed.md"),
+]
+
+CSS = """
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-size: 11pt;
+    line-height: 1.5;
+    color: #262626;
+    max-width: 210mm;
+    margin: 0 auto;
+    padding: 20mm 15mm;
+}
+h1 {
+    color: #0067C5;
+    border-bottom: 3px solid #0067C5;
+    padding-bottom: 8px;
+    font-size: 22pt;
+    page-break-before: always;
+}
+h1:first-child { page-break-before: avoid; }
+h2 {
+    color: #0067C5;
+    font-size: 16pt;
+    margin-top: 24px;
+    border-bottom: 1px solid #CCE1F3;
+    padding-bottom: 4px;
+}
+h3 {
+    color: #333;
+    font-size: 13pt;
+    margin-top: 18px;
+}
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 12px 0;
+    font-size: 9.5pt;
+}
+th {
+    background-color: #0067C5;
+    color: white;
+    padding: 8px 6px;
+    text-align: left;
+    font-weight: 600;
+}
+td {
+    padding: 6px;
+    border-bottom: 1px solid #ddd;
+    vertical-align: top;
+}
+tr:nth-child(even) { background-color: #f8f9fa; }
+code {
+    background-color: #f0f4f8;
+    padding: 2px 5px;
+    border-radius: 3px;
+    font-size: 9pt;
+    font-family: 'SF Mono', Monaco, Menlo, monospace;
+}
+pre {
+    background-color: #f0f4f8;
+    padding: 12px;
+    border-radius: 6px;
+    font-size: 8.5pt;
+    overflow-x: auto;
+    border-left: 4px solid #0067C5;
+}
+pre code { background: none; padding: 0; }
+strong { color: #1a1a1a; }
+hr {
+    border: none;
+    border-top: 2px solid #CCE1F3;
+    margin: 24px 0;
+}
+.cover-page {
+    text-align: center;
+    padding-top: 120px;
+}
+"""
+
+COVER_PAGE = """
+<div style="text-align: center; padding-top: 100px;">
+<h1 style="border: none; color: #0067C5; font-size: 28pt; page-break-before: avoid;">
+Risiko- og sårbarhetsanalyse
+</h1>
+<h2 style="border: none; color: #333; font-size: 18pt;">
+samordning-hendelse-api
+</h2>
+<p style="font-size: 14pt; color: #666; margin-top: 40px;">
+PersonFeedController &amp; ManglendeRefusjonFeedController
+</p>
+<br/><br/>
+<table style="width: 50%; margin: 40px auto; font-size: 11pt;">
+<tr><td style="border: none; text-align: right; color: #666; padding: 4px 12px;"><strong>Team:</strong></td>
+<td style="border: none; padding: 4px 12px;">pensjonsamhandling</td></tr>
+<tr><td style="border: none; text-align: right; color: #666; padding: 4px 12px;"><strong>Dato:</strong></td>
+<td style="border: none; padding: 4px 12px;">2026-05-27</td></tr>
+<tr><td style="border: none; text-align: right; color: #666; padding: 4px 12px;"><strong>Versjon:</strong></td>
+<td style="border: none; padding: 4px 12px;">1.0</td></tr>
+<tr><td style="border: none; text-align: right; color: #666; padding: 4px 12px;"><strong>Klassifisering:</strong></td>
+<td style="border: none; padding: 4px 12px;">Intern</td></tr>
+</table>
+</div>
+"""
+
+
+def main():
+    css_file = os.path.join(SCRIPT_DIR, ".ros-style.css")
+    with open(css_file, "w") as f:
+        f.write(CSS)
+
+    for md_file in MARKDOWN_FILES:
+        if not os.path.exists(md_file):
+            print(f"ERROR: {md_file} not found")
+            sys.exit(1)
+
+    # Convert each markdown to HTML fragment
+    html_parts = [COVER_PAGE]
+    for md_file in MARKDOWN_FILES:
+        result = subprocess.run(
+            ["pandoc", "-f", "markdown", "-t", "html5", "--wrap=none", md_file],
+            capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            print(f"ERROR pandoc: {result.stderr}")
+            sys.exit(1)
+        html_parts.append(result.stdout)
+
+    # Combine into full HTML
+    full_html = f"""<!DOCTYPE html>
+<html lang="no">
+<head>
+<meta charset="utf-8"/>
+<style>{CSS}</style>
+</head>
+<body>
+{'<div style="page-break-after: always;"></div>'.join(html_parts)}
+</body>
+</html>"""
+
+    html_file = os.path.join(SCRIPT_DIR, ".ros-combined.html")
+    with open(html_file, "w") as f:
+        f.write(full_html)
+
+    # Try multiple PDF conversion methods
+    pdf_generated = False
+
+    # Method 1: pandoc with built-in HTML engine
+    try:
+        result = subprocess.run(
+            ["pandoc", html_file, "-f", "html", "-t", pdf_engine(),
+             "-o", OUTPUT_PDF,
+             "--pdf-engine=wkhtmltopdf"],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode == 0:
+            pdf_generated = True
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    # Method 2: Use Python reportlab
+    if not pdf_generated:
+        print("Pandoc PDF failed, using reportlab...")
+        pdf_generated = generate_pdf_reportlab(html_file)
+
+    # Clean up temp files
+    for f in [css_file, html_file]:
+        if os.path.exists(f):
+            os.remove(f)
+
+    if pdf_generated:
+        print(f"PDF generated: {OUTPUT_PDF}")
+    else:
+        # Fallback: save HTML for manual conversion
+        fallback = os.path.join(SCRIPT_DIR, "ros-samordning-feeds.html")
+        with open(fallback, "w") as f:
+            f.write(full_html)
+        print(f"PDF generation failed. HTML saved: {fallback}")
+        print("Open the HTML file in a browser and print to PDF.")
+
+
+def pdf_engine():
+    """Detect available PDF engine for pandoc."""
+    for engine in ["xelatex", "pdflatex", "wkhtmltopdf", "weasyprint"]:
+        try:
+            subprocess.run(["which", engine], capture_output=True, check=True)
+            return "pdf"
+        except subprocess.CalledProcessError:
+            continue
+    return "html"
+
+
+def generate_pdf_reportlab(html_file):
+    """Generate PDF using reportlab."""
+    try:
+        from reportlab.lib.pagesizes import A4
+        from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+        from reportlab.lib.units import mm
+        from reportlab.lib.colors import HexColor
+        from reportlab.platypus import (
+            SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle,
+            PageBreak, HRFlowable
+        )
+        from reportlab.lib.enums import TA_CENTER, TA_LEFT
+
+        doc = SimpleDocTemplate(
+            OUTPUT_PDF, pagesize=A4,
+            leftMargin=20*mm, rightMargin=20*mm,
+            topMargin=20*mm, bottomMargin=20*mm
+        )
+
+        styles = getSampleStyleSheet()
+        nav_blue = HexColor("#0067C5")
+        nav_light = HexColor("#CCE1F3")
+
+        styles.add(ParagraphStyle(
+            'CoverTitle', parent=styles['Title'],
+            fontSize=26, textColor=nav_blue, spaceAfter=12, alignment=TA_CENTER
+        ))
+        styles.add(ParagraphStyle(
+            'CoverSubtitle', parent=styles['Title'],
+            fontSize=16, textColor=HexColor("#333"), spaceAfter=8, alignment=TA_CENTER
+        ))
+        styles.add(ParagraphStyle(
+            'CoverMeta', parent=styles['Normal'],
+            fontSize=12, textColor=HexColor("#666"), alignment=TA_CENTER, spaceAfter=4
+        ))
+        styles.add(ParagraphStyle(
+            'H1', parent=styles['Heading1'],
+            fontSize=20, textColor=nav_blue, spaceBefore=24, spaceAfter=10,
+            borderWidth=2, borderColor=nav_blue, borderPadding=4
+        ))
+        styles.add(ParagraphStyle(
+            'H2', parent=styles['Heading2'],
+            fontSize=14, textColor=nav_blue, spaceBefore=16, spaceAfter=8
+        ))
+        styles.add(ParagraphStyle(
+            'H3', parent=styles['Heading3'],
+            fontSize=12, textColor=HexColor("#333"), spaceBefore=12, spaceAfter=6
+        ))
+        styles.add(ParagraphStyle(
+            'BodyText2', parent=styles['Normal'],
+            fontSize=10, leading=14, spaceAfter=6
+        ))
+        styles.add(ParagraphStyle(
+            'CellText', parent=styles['Normal'],
+            fontSize=8, leading=10
+        ))
+        styles.add(ParagraphStyle(
+            'CellHeader', parent=styles['Normal'],
+            fontSize=8, leading=10, textColor=HexColor("#FFFFFF"), fontName='Helvetica-Bold'
+        ))
+
+        story = []
+
+        # Cover page
+        story.append(Spacer(1, 80*mm))
+        story.append(Paragraph("Risiko- og sårbarhetsanalyse", styles['CoverTitle']))
+        story.append(Spacer(1, 8*mm))
+        story.append(Paragraph("samordning-hendelse-api", styles['CoverSubtitle']))
+        story.append(Spacer(1, 12*mm))
+        story.append(Paragraph("PersonFeedController &amp; ManglendeRefusjonFeedController", styles['CoverMeta']))
+        story.append(Spacer(1, 20*mm))
+        story.append(Paragraph("Team: pensjonsamhandling", styles['CoverMeta']))
+        story.append(Paragraph("Dato: 2026-05-27", styles['CoverMeta']))
+        story.append(Paragraph("Versjon: 1.0", styles['CoverMeta']))
+        story.append(Paragraph("Klassifisering: Intern", styles['CoverMeta']))
+        story.append(PageBreak())
+
+        # Parse and render each markdown file
+        for md_file in MARKDOWN_FILES:
+            with open(md_file, 'r') as f:
+                lines = f.readlines()
+
+            i = 0
+            table_rows = []
+            in_table = False
+
+            while i < len(lines):
+                line = lines[i].rstrip()
+
+                # Skip empty lines
+                if not line:
+                    if in_table and table_rows:
+                        story.append(build_table(table_rows, styles))
+                        table_rows = []
+                        in_table = False
+                    i += 1
+                    continue
+
+                # Headers
+                if line.startswith('# ') and not line.startswith('## '):
+                    if in_table and table_rows:
+                        story.append(build_table(table_rows, styles))
+                        table_rows = []
+                        in_table = False
+                    story.append(Paragraph(clean_md(line[2:]), styles['H1']))
+                    i += 1
+                    continue
+                if line.startswith('## '):
+                    if in_table and table_rows:
+                        story.append(build_table(table_rows, styles))
+                        table_rows = []
+                        in_table = False
+                    story.append(Paragraph(clean_md(line[3:]), styles['H2']))
+                    i += 1
+                    continue
+                if line.startswith('### '):
+                    if in_table and table_rows:
+                        story.append(build_table(table_rows, styles))
+                        table_rows = []
+                        in_table = False
+                    story.append(Paragraph(clean_md(line[4:]), styles['H3']))
+                    i += 1
+                    continue
+
+                # Horizontal rule
+                if line.startswith('---'):
+                    if in_table and table_rows:
+                        story.append(build_table(table_rows, styles))
+                        table_rows = []
+                        in_table = False
+                    story.append(HRFlowable(width="100%", color=nav_light, thickness=2, spaceAfter=8, spaceBefore=8))
+                    i += 1
+                    continue
+
+                # Table
+                if '|' in line and line.strip().startswith('|'):
+                    cells = [c.strip() for c in line.strip().strip('|').split('|')]
+                    # Skip separator rows
+                    if all(c.replace('-', '').replace(':', '') == '' for c in cells):
+                        i += 1
+                        continue
+                    table_rows.append(cells)
+                    in_table = True
+                    i += 1
+                    continue
+
+                # Code block
+                if line.startswith('```'):
+                    if in_table and table_rows:
+                        story.append(build_table(table_rows, styles))
+                        table_rows = []
+                        in_table = False
+                    code_lines = []
+                    i += 1
+                    while i < len(lines) and not lines[i].strip().startswith('```'):
+                        code_lines.append(lines[i].rstrip())
+                        i += 1
+                    code_text = '<br/>'.join(
+                        l.replace(' ', '&nbsp;').replace('<', '&lt;').replace('>', '&gt;')
+                        for l in code_lines
+                    )
+                    story.append(Paragraph(
+                        f'<font face="Courier" size="7">{code_text}</font>',
+                        ParagraphStyle('Code', parent=styles['Normal'],
+                                      backColor=HexColor("#f0f4f8"),
+                                      borderWidth=0, leftIndent=8,
+                                      spaceBefore=6, spaceAfter=6,
+                                      fontSize=7, leading=9)
+                    ))
+                    i += 1
+                    continue
+
+                # Regular paragraph
+                if in_table and table_rows:
+                    story.append(build_table(table_rows, styles))
+                    table_rows = []
+                    in_table = False
+                story.append(Paragraph(clean_md(line), styles['BodyText2']))
+                i += 1
+
+            # Flush remaining table
+            if in_table and table_rows:
+                story.append(build_table(table_rows, styles))
+
+            story.append(PageBreak())
+
+        doc.build(story)
+        return True
+
+    except Exception as e:
+        print(f"Reportlab error: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def build_table(rows, styles):
+    """Build a reportlab Table from parsed markdown table rows."""
+    from reportlab.platypus import Table, TableStyle, Paragraph
+    from reportlab.lib.colors import HexColor
+    from reportlab.lib.units import mm
+
+    nav_blue = HexColor("#0067C5")
+    cell_style = styles['CellText']
+    header_style = styles['CellHeader']
+
+    # Convert to Paragraphs for wrapping
+    data = []
+    for ri, row in enumerate(rows):
+        style = header_style if ri == 0 else cell_style
+        data.append([Paragraph(clean_md(cell), style) for cell in row])
+
+    num_cols = max(len(r) for r in data)
+    col_width = (170*mm) / num_cols
+
+    t = Table(data, colWidths=[col_width]*num_cols, repeatRows=1)
+    table_style = [
+        ('BACKGROUND', (0, 0), (-1, 0), nav_blue),
+        ('TEXTCOLOR', (0, 0), (-1, 0), HexColor("#FFFFFF")),
+        ('FONTSIZE', (0, 0), (-1, -1), 8),
+        ('BOTTOMPADDING', (0, 0), (-1, -1), 4),
+        ('TOPPADDING', (0, 0), (-1, -1), 4),
+        ('LEFTPADDING', (0, 0), (-1, -1), 4),
+        ('RIGHTPADDING', (0, 0), (-1, -1), 4),
+        ('GRID', (0, 0), (-1, -1), 0.5, HexColor("#ddd")),
+        ('VALIGN', (0, 0), (-1, -1), 'TOP'),
+    ]
+    # Alternating row colors
+    for ri in range(1, len(data)):
+        if ri % 2 == 0:
+            table_style.append(('BACKGROUND', (0, ri), (-1, ri), HexColor("#f8f9fa")))
+
+    t.setStyle(TableStyle(table_style))
+    return t
+
+
+def clean_md(text):
+    """Clean markdown formatting for reportlab Paragraph."""
+    import re
+    text = re.sub(r'\*\*(.+?)\*\*', r'<b>\1</b>', text)
+    text = re.sub(r'`(.+?)`', r'<font face="Courier" size="8">\1</font>', text)
+    text = text.replace('🟢', '●').replace('🟡', '◐').replace('🔴', '○')
+    text = text.replace('—', '–')
+    return text
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/ros/ros-manglende-refusjon-feed.md
+++ b/docs/ros/ros-manglende-refusjon-feed.md
@@ -1,0 +1,132 @@
+# Risiko- og sårbarhetsanalyse (ROS)
+## ManglendeRefusjonFeedController — `/hendelser/manglendeRefusjonskrav`
+
+**System:** samordning-hendelse-api  
+**Team:** pensjonsamhandling  
+**Dato:** 2026-05-27  
+**Versjon:** 1.0  
+
+---
+
+## 1. Systembeskrivelse
+
+### Formål
+ManglendeRefusjonFeedController eksponerer en paginert feed med hendelser om manglende refusjonskrav til eksterne tjenestepensjons­leverandører (TP-leverandører). Feeden varsler TP-leverandører om at det finnes samordningsvedtak der refusjonskrav mangler, med en svarfrist.
+
+### Dataflyt
+```
+Kafka (manglende-refusjonskrav) → ManglendeRefusjonskravListener → PostgreSQL (MANGLENDE_REFUSJONSKRAV)
+                                                                          ↓
+Eksterne TP-leverandører → KrakenD Gateway → ManglendeRefusjonFeedController → Service → DB
+```
+
+### Dataklassifisering: MODERAT
+Endepunktet eksponerer følgende data:
+
+| Felt | Kategori | Hjemmel |
+|------|----------|---------|
+| `fnr` | Fødselsnummer | Samordningsloven |
+| `samId` | Samordnings-ID (referanse til vedtak) | Samordningsloven |
+| `svarfrist` | Frist for innsending av refusjonskrav | Samordningsloven |
+| `tpnr` | Tjenestepensjonsordningens nummer | Samordningsloven |
+
+### Autentisering og autorisasjon
+- **Autentisering:** Maskinporten med scope `nav:pensjon/v1/samordning`
+- **Autorisasjon:** TpConfigOrgNoValidator — validerer at organisasjonsnummer i token matcher tpnr-parameteren via tp-config-tjenesten
+- **API Gateway:** KrakenD med rate limiting (100 req/60s) — aktiv i q2, planlagt for prod
+
+---
+
+## 2. Skala-definisjoner
+
+### Sannsynlighet (S)
+| Verdi | Beskrivelse |
+|-------|-------------|
+| 1 | Svært lite sannsynlig — krever ekstraordinære omstendigheter |
+| 2 | Lite sannsynlig — kan skje, men usannsynlig |
+| 3 | Moderat — kan skje i løpet av systemets levetid |
+| 4 | Sannsynlig — forventes å skje |
+| 5 | Svært sannsynlig — forventes å skje ofte |
+
+### Konsekvens (K)
+| Verdi | Beskrivelse |
+|-------|-------------|
+| 1 | Ubetydelig — ingen merkbar effekt |
+| 2 | Lav — mindre ulempe, raskt håndtert |
+| 3 | Moderat — merkbar påvirkning, krever oppfølging |
+| 4 | Alvorlig — betydelig skade for person/organisasjon |
+| 5 | Svært alvorlig — alvorlig personvernbrudd, omdømmeskade |
+
+### Risikoverdi (R = S × K)
+| Nivå | Verdi | Aksept |
+|------|-------|--------|
+| 🟢 Grønn | 1–6 | Akseptabel risiko |
+| 🟡 Gul | 7–12 | Bør reduseres, tiltak vurderes |
+| 🔴 Rød | 13–25 | Uakseptabel, tiltak påkrevd |
+
+---
+
+## 3. Risikovurdering
+
+### Felles risikoer (delt med alle feed-kontrollere)
+
+| ID | Uønsket hendelse | S | K | R | Eksisterende tiltak | Foreslåtte tiltak | Restrisiko |
+|----|-------------------|---|---|---|---------------------|-------------------|------------|
+| F-01 | **Ugyldig Maskinporten-token aksepteres** — angriper forfalker token og får tilgang til feed | 1 | 5 | 🟢 5 | Maskinporten-validering med JWK-verifisering, scope-sjekk (`nav:pensjon/v1/samordning`) | Ingen — tilstrekkelig sikret | 🟢 Lav |
+| F-02 | **TpConfig er nede** — autorisasjonssjekk feiler, forespørsler avvises | 3 | 3 | 🟡 9 | TpConfigConsumer har connect-timeout (3s) og read-timeout (5s). Feil returnerer HTTP 500 | Vurdere caching av tp-config-svar for kort tid (f.eks. 5 min) for å redusere avhengighet | 🟢 Lav |
+| F-03 | **Input-manipulasjon** — angriper sender ugyldige parametere for å trigge feil eller uventede spørringer | 2 | 2 | 🟢 4 | Jakarta Bean Validation: `@Digits(4,0)` for tpnr, `@Min`/`@Max` for paginering, `@PositiveOrZero` for side. FeedExceptionHandler returnerer 400 | Ingen — tilstrekkelig sikret | 🟢 Lav |
+| F-04 | **Manglende rate limiting på direkte ingress (prod)** — TP-leverandør overbelaster tjenesten via direkte URL | 2 | 3 | 🟢 6 | KrakenD har rate limiting (100/60s) i q2. I prod brukes foreløpig direkte ingress uten rate limiting. Maskinporten begrenser tilgang til autoriserte aktører | Legge til KrakenD-routing i prod etter ekstern testing. Vurdere Spring-basert rate limiting som fallback | 🟢 Lav |
+| F-05 | **Manglende audit-logging** — kan ikke spore hvem som hentet hvilke data | 2 | 4 | 🟡 8 | Maskinporten-token inneholder orgno. TpConfigConsumer logger `validateOrganisation status [orgno, tpnr]`. Controller logger tpnr og antall hendelser på DEBUG-nivå | Logge orgno + tpnr + antall hendelser på INFO-nivå for alle forespørsler. Ikke logg fnr | 🟡 Moderat |
+
+### Spesifikke risikoer for ManglendeRefusjonFeedController
+
+| ID | Uønsket hendelse | S | K | R | Eksisterende tiltak | Foreslåtte tiltak | Restrisiko |
+|----|-------------------|---|---|---|---------------------|-------------------|------------|
+| R-01 | **Uautorisert tilgang til refusjonskrav-data** — TP-leverandør henter data for tpnr de ikke eier | 1 | 4 | 🟢 4 | TpConfigOrgNoValidator sjekker at orgno matcher tpnr. Maskinporten sikrer identitet | Ingen — tilstrekkelig sikret | 🟢 Lav |
+| R-02 | **SamId-kobling avslører vedtaksinformasjon** — samId kan brukes til kryss-referering med vedtaks-feeden for å bygge utvidet profil | 2 | 3 | 🟢 6 | SamId er en intern referanse. TP-leverandøren har allerede tilgang til vedtaks-feeden med samme tpnr-filtrering. Ingen ekstra informasjon oppnås | Dokumentere at samId er ment for kryss-referanse — dette er tilsiktet bruk | 🟢 Lav |
+| R-03 | **Manglende forretningsmetrikker** — kan ikke oppdage unormal bruk eller misbruk | 3 | 3 | 🟡 9 | Micrometer `@Timed` gir generelle HTTP-metrikker. Prometheus-endepunkt er aktivert. Ingen domenespesifikke metrikker | Legge til `AppMetrics.incManglendeRefusjonskravLest(tpnr, count)` tilsvarende vedtak-feedens mønster. Sette opp Grafana-alert ved unormal bruksmønster | 🟢 Lav |
+| R-04 | **Utløpt svarfrist oppdages ikke** — TP-leverandør leser feeden for sent og mister fristen | 3 | 3 | 🟡 9 | Svarfrist er inkludert i responsen. TP-leverandøren er ansvarlig for å lese feeden regelmessig | Vurdere metrikk/alert for hendelser med svarfrist som nærmer seg. Dokumentere SLA for feed-polling i API-dokumentasjon | 🟡 Moderat |
+| R-05 | **Duplikat-sjekk på samId hindrer reell re-sending** — dersom en Kafka-melding må sendes på nytt med oppdatert svarfrist, avvises den | 2 | 3 | 🟢 6 | `findBySamId` returnerer eksisterende og listener ACKer uten lagring. Hindrer duplikater | Vurdere om oppdatering av eksisterende rad (f.eks. ny svarfrist) er ønsket i stedet for avvisning. Dokumentere forventet oppførsel | 🟢 Lav |
+| R-06 | **Database-spørring returnerer data for feil TP-leverandør** — feil i sekvensnummer-logikk gir tilgang til andres data | 1 | 4 | 🟢 4 | `findByTpnrAndSekvensnummerBetween` filtrerer alltid på tpnr. JPA parameteriserte spørringer hindrer SQL-injection | Ingen — tilstrekkelig sikret | 🟢 Lav |
+
+---
+
+## 4. Risikomatrise — ManglendeRefusjonFeedController
+
+```
+K o n s e k v e n s →
+        1       2       3       4       5
+  5 ┌───────┬───────┬───────┬───────┬───────┐
+S   │       │       │       │       │       │
+a 4 ├───────┼───────┼───────┼───────┼───────┤
+n   │       │       │       │       │       │
+n 3 ├───────┼───────┼───────┼───────┼───────┤
+s   │       │       │ R-03  │       │       │
+y   │       │       │ R-04  │       │       │
+n 2 ├───────┼───────┼───────┼───────┼───────┤
+l   │       │ F-03  │ R-02  │ F-05  │       │
+i   │       │       │ R-05  │       │       │
+g 1 ├───────┼───────┼───────┼───────┼───────┤
+h   │       │       │       │ R-01  │ F-01  │
+e   │       │       │       │ R-06  │       │
+t   │       │       │       │       │       │
+  ↓ └───────┴───────┴───────┴───────┴───────┘
+```
+
+---
+
+## 5. Oppsummering og anbefalinger
+
+### Aksepterte risikoer (🟢)
+- F-01, F-03, F-04, R-01, R-02, R-05, R-06 — tilstrekkelig sikret med eksisterende tiltak
+
+### Risikoer som bør reduseres (🟡)
+| ID | Tiltak | Prioritet |
+|----|--------|-----------|
+| F-05 | Audit-logging på INFO-nivå med orgno+tpnr | Middels |
+| R-04 | Dokumentere SLA for feed-polling, vurdere svarfrist-alert | Middels |
+| F-02 | Vurdere caching av tp-config-validering | Lav |
+| R-03 | Legge til AppMetrics for refusjonskrav-feed | Lav |
+
+### Konklusjon
+Tjenesten har en **akseptabel risikoprofil**. Dataklassifiseringen er lavere enn person-feeden (ingen adresse, sivilstand eller dødsdato). Hovedbekymringen er **svarfrist-håndtering** (R-04) — det bør dokumenteres tydelig for TP-leverandører hva som er forventet polling-frekvens for å sikre at svarfrister overholdes.

--- a/docs/ros/ros-person-feed.md
+++ b/docs/ros/ros-person-feed.md
@@ -1,0 +1,137 @@
+# Risiko- og sårbarhetsanalyse (ROS)
+## PersonFeedController — `/hendelser/personer`
+
+**System:** samordning-hendelse-api  
+**Team:** pensjonsamhandling  
+**Dato:** 2026-05-27  
+**Versjon:** 1.0  
+
+---
+
+## 1. Systembeskrivelse
+
+### Formål
+PersonFeedController eksponerer en paginert feed med personendringshendelser (sivilstandsendring, adresseendring, dødsfallsmelding, fødselsnummerendring) til eksterne tjenestepensjons­leverandører (TP-leverandører).
+
+### Dataflyt
+```
+Kafka (person-endring) → PersonEndringListener → PostgreSQL (PERSON_ENDRING)
+                                                        ↓
+Eksterne TP-leverandører → KrakenD Gateway → PersonFeedController → PersonService → DB
+```
+
+### Dataklassifisering: HØYT
+Endepunktet eksponerer følgende personopplysninger:
+
+| Felt | Kategori | Hjemmel |
+|------|----------|---------|
+| `fnr` | Fødselsnummer | Samordningsloven |
+| `fnrGammelt` | Tidligere fødselsnummer | Samordningsloven |
+| `sivilstand` | Sivilstatus | Samordningsloven |
+| `sivilstandDato` | Dato for sivilstandsendring | Samordningsloven |
+| `doedsdato` | Dødsdato | Samordningsloven |
+| `adresse` | Fullstendig adresse (linje1-3, postnr, poststed, land) | Samordningsloven |
+| `meldingskode` | Type hendelse (SIVILSTAND, FODSELSNUMMER, ADRESSE, DOEDSFALL) | Samordningsloven |
+
+### Autentisering og autorisasjon
+- **Autentisering:** Maskinporten med scope `nav:pensjon/v1/samordning`
+- **Autorisasjon:** TpConfigOrgNoValidator — validerer at organisasjonsnummer i token matcher tpnr-parameteren via tp-config-tjenesten
+- **API Gateway:** KrakenD med rate limiting (100 req/60s) — aktiv i q2, planlagt for prod
+
+---
+
+## 2. Skala-definisjoner
+
+### Sannsynlighet (S)
+| Verdi | Beskrivelse |
+|-------|-------------|
+| 1 | Svært lite sannsynlig — krever ekstraordinære omstendigheter |
+| 2 | Lite sannsynlig — kan skje, men usannsynlig |
+| 3 | Moderat — kan skje i løpet av systemets levetid |
+| 4 | Sannsynlig — forventes å skje |
+| 5 | Svært sannsynlig — forventes å skje ofte |
+
+### Konsekvens (K)
+| Verdi | Beskrivelse |
+|-------|-------------|
+| 1 | Ubetydelig — ingen merkbar effekt |
+| 2 | Lav — mindre ulempe, raskt håndtert |
+| 3 | Moderat — merkbar påvirkning, krever oppfølging |
+| 4 | Alvorlig — betydelig skade for person/organisasjon |
+| 5 | Svært alvorlig — alvorlig personvernbrudd, omdømmeskade |
+
+### Risikoverdi (R = S × K)
+| Nivå | Verdi | Aksept |
+|------|-------|--------|
+| 🟢 Grønn | 1–6 | Akseptabel risiko |
+| 🟡 Gul | 7–12 | Bør reduseres, tiltak vurderes |
+| 🔴 Rød | 13–25 | Uakseptabel, tiltak påkrevd |
+
+---
+
+## 3. Risikovurdering
+
+### Felles risikoer (delt med alle feed-kontrollere)
+
+| ID | Uønsket hendelse | S | K | R | Eksisterende tiltak | Foreslåtte tiltak | Restrisiko |
+|----|-------------------|---|---|---|---------------------|-------------------|------------|
+| F-01 | **Ugyldig Maskinporten-token aksepteres** — angriper forfalker token og får tilgang til feed | 1 | 5 | 🟢 5 | Maskinporten-validering med JWK-verifisering, scope-sjekk (`nav:pensjon/v1/samordning`) | Ingen — tilstrekkelig sikret | 🟢 Lav |
+| F-02 | **TpConfig er nede** — autorisasjonssjekk feiler, forespørsler avvises | 3 | 3 | 🟡 9 | TpConfigConsumer har connect-timeout (3s) og read-timeout (5s). Feil returnerer HTTP 500 | Vurdere caching av tp-config-svar for kort tid (f.eks. 5 min) for å redusere avhengighet | 🟢 Lav |
+| F-03 | **Input-manipulasjon** — angriper sender ugyldige parametere for å trigge feil eller uventede spørringer | 2 | 2 | 🟢 4 | Jakarta Bean Validation: `@Digits(4,0)` for tpnr, `@Min`/`@Max` for paginering, `@PositiveOrZero` for side. FeedExceptionHandler returnerer 400 | Ingen — tilstrekkelig sikret | 🟢 Lav |
+| F-04 | **Manglende rate limiting på direkte ingress (prod)** — TP-leverandør overbelaster tjenesten via direkte URL | 2 | 3 | 🟢 6 | KrakenD har rate limiting (100/60s) i q2. I prod brukes foreløpig direkte ingress uten rate limiting. Maskinporten begrenser tilgang til autoriserte aktører | Legge til KrakenD-routing i prod etter ekstern testing. Vurdere Spring-basert rate limiting som fallback | 🟢 Lav |
+| F-05 | **Manglende audit-logging** — kan ikke spore hvem som hentet hvilke data | 2 | 4 | 🟡 8 | Maskinporten-token inneholder orgno. TpConfigConsumer logger `validateOrganisation status [orgno, tpnr]`. Controller logger tpnr og antall hendelser på DEBUG-nivå | Logge orgno + tpnr + antall hendelser på INFO-nivå for alle forespørsler. Ikke logg fnr | 🟡 Moderat |
+
+### Spesifikke risikoer for PersonFeedController
+
+| ID | Uønsket hendelse | S | K | R | Eksisterende tiltak | Foreslåtte tiltak | Restrisiko |
+|----|-------------------|---|---|---|---------------------|-------------------|------------|
+| P-01 | **Uautorisert tilgang til personsensitive data** — TP-leverandør henter persondata for tpnr de ikke eier | 1 | 5 | 🟢 5 | TpConfigOrgNoValidator sjekker at orgno matcher tpnr. Maskinporten sikrer identitet | Ingen — tilstrekkelig sikret | 🟢 Lav |
+| P-02 | **Overeksponering av data** — TP-leverandør mottar mer persondata enn nødvendig for samordning | 3 | 4 | 🟡 12 | Alle felter returneres alltid (fnr, adresse, sivilstand, dødsdato). Responsen er et fast skjema — ingen feltfiltrering | Vurdere om alle felter alltid er nødvendige. Meldingskode indikerer type endring — vurder å kun inkludere relevante felter per meldingskode. Dokumentere dataminimering i API-kontrakt | 🟡 Moderat |
+| P-03 | **Persondata lekker i logger** — fnr eller andre PII skrives til logg | 2 | 5 | 🟡 10 | Controller logger kun `tpnr` og `hendelser.size` på DEBUG-nivå. Ingen fnr i logger. Kafka-listener logger `hendelseId` og `meldingskode` | Gjennomgå at logback-config maskerer evt. PII i stack traces. Legge til PII-scanning i CI/CD | 🟡 Moderat |
+| P-04 | **Manglende forretningsmetrikker** — kan ikke oppdage unormal bruk eller misbruk | 3 | 3 | 🟡 9 | Micrometer `@Timed` gir generelle HTTP-metrikker. Prometheus-endepunkt er aktivert. Ingen domenespesifikke metrikker (i motsetning til vedtak/ytelse som har `AppMetrics`) | Legge til `AppMetrics.incPersonHendelserLest(tpnr, count)` tilsvarende vedtak-feedens mønster. Sette opp Grafana-alert ved unormal bruksmønster | 🟢 Lav |
+| P-05 | **Adressedata eksponeres unødvendig** — full adresse (linje1-3, postnr, poststed, land) sendes ved alle meldingskoder, ikke bare ADRESSE | 3 | 3 | 🟡 9 | Adresse-feltet er nullable — settes kun ved ADRESSE-meldingskode fra Kafka-listener | Verifisere at adresse kun populeres for ADRESSE-meldingskode i alle tilfeller. Dokumentere dette i API-spesifikasjon | 🟢 Lav |
+| P-06 | **Database-spørring returnerer data for feil TP-leverandør** — feil i sekvensnummer-logikk gir tilgang til andres data | 1 | 5 | 🟢 5 | `findByTpnrAndSekvensnummerBetween` filtrerer alltid på tpnr. JPA parameteriserte spørringer hindrer SQL-injection | Ingen — tilstrekkelig sikret | 🟢 Lav |
+
+---
+
+## 4. Risikomatrise — PersonFeedController
+
+```
+K o n s e k v e n s →
+        1       2       3       4       5
+  5 ┌───────┬───────┬───────┬───────┬───────┐
+S   │       │       │       │       │       │
+a 4 ├───────┼───────┼───────┼───────┼───────┤
+n   │       │       │       │       │       │
+n 3 ├───────┼───────┼───────┼───────┼───────┤
+s   │       │       │ P-04  │ P-02  │       │
+y   │       │       │ P-05  │       │       │
+n 2 ├───────┼───────┼───────┼───────┼───────┤
+l   │       │ F-03  │ F-04  │ F-05  │ P-03  │
+i   │       │       │       │       │       │
+g 1 ├───────┼───────┼───────┼───────┼───────┤
+h   │       │       │       │       │F-01   │
+e   │       │       │       │       │P-01   │
+t   │       │       │       │       │P-06   │
+  ↓ └───────┴───────┴───────┴───────┴───────┘
+```
+
+---
+
+## 5. Oppsummering og anbefalinger
+
+### Aksepterte risikoer (🟢)
+- F-01, F-03, F-04, P-01, P-06 — tilstrekkelig sikret med eksisterende tiltak
+
+### Risikoer som bør reduseres (🟡)
+| ID | Tiltak | Prioritet |
+|----|--------|-----------|
+| P-02 | Vurdere dataminimering per meldingskode | Høy |
+| P-03 | PII-scanning i CI/CD, logback-gjennomgang | Middels |
+| F-05 | Audit-logging på INFO-nivå med orgno+tpnr | Middels |
+| P-04 | Legge til AppMetrics for person-feed | Lav |
+| F-02 | Vurdere caching av tp-config-validering | Lav |
+| P-05 | Verifisere adresse-populering, dokumentere | Lav |
+
+### Konklusjon
+Tjenesten har en **akseptabel risikoprofil** med grundig autentisering og autorisasjon. Hovedbekymringen er **dataminimering** (P-02) — person-feeden eksponerer potensielt mer data enn nødvendig per hendelsestype. Dette bør vurderes som en forbedring.


### PR DESCRIPTION
Risiko- og sårbarhetsanalyse for de to nye feed-kontrollerne:
- PersonFeedController (/hendelser/personer) — høy dataklassifisering
- ManglendeRefusjonFeedController (/hendelser/manglendeRefusjonskrav) — moderat

17 risikoer identifisert (5 felles, 6 person, 6 refusjon). 0 røde, 7 gule, 10 grønne. Ingen blokkerende funn.

Inkluderer Python-script for PDF-generering (reportlab). PDF er gitignored — regenerer med: cd docs/ros && python3 generate-pdf.py